### PR TITLE
fix promotion captures

### DIFF
--- a/Chess-Challenge/src/Chess/Move Generation/MoveGenerator.cs
+++ b/Chess-Challenge/src/Chess/Move Generation/MoveGenerator.cs
@@ -258,7 +258,7 @@ namespace ChessChallenge.Chess
             }
 
             // Captures
-            GeneratePawnCaptures(moves, pawns, enemyPieces, pushDir);
+            GeneratePawnCaptures(moves, pawns, enemyPieces & (~promotionRankMask), pushDir);
 
             // Promotions
             while (pushPromotions != 0)


### PR DESCRIPTION
capture promotions worked "correctly" but in addition there was generated just a capture on the last rank, which ended with just taking a piece on last rank without promoting. 